### PR TITLE
Feature/ Check for available port

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The CLI-Tool includes the following functionalities:
 
 ### How to use the Websocket: 
 
-The websocket currently can be used in a client-based setup. 
+The websocket currently can be used in a client-based setup. The Websocket is running on a port between 8080 and 8170 depending on which port is available. It starts with 8080 and then counts up.  
 
 2. Using the Websocket in a Client-based Setup 
 
@@ -41,13 +41,13 @@ Run the Websocket in the backend without specifying any UUIDS with the command :
 Step 2: Retrieve UUIDS via REST API 
 On the client side, request the available UUIDs by accessing the REST API endpoint:
 ```
-http://<ip>:8080/UUID
+http://<ip>:<port>/UUID
 ```
 
 Step 3: Connect to the WS 
 Establish a WS connection via
 ```
-wscat -c ws://127.0.0.1:8080/ws
+wscat -c ws://<ip>:<port>/ws
 ```
 
 Step 4: Start the measurement


### PR DESCRIPTION
## What ? 

Changed the available port of the websocket from a static port (8080) to search for a free port betwenn 8080 and 8170 on the system. Now the websocket does not get a problem if the static port is blocked. 

## Why ? 

As the program can be used in many different setups, port 8080 is used in several cases. Therefore programm should not depend on a static port to work. 

## How ? 
Implementation of a search function to find an available port with boost. Starting the WS with crow on the available port.

## Testing 

Bind port 8080 on your system to another process : 

Testscript with python: 

```

import socket

# Creat TCP Socket
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

# exclusiv binding 
# s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  ← das NICHT benutzen

# bind port 8080 to ip 0.0.0.0
try:
    s.bind(("0.0.0.0", 8080))
    s.listen(1)
    print("Press enter to close programm")
    input()
except OSError as e:
    print(f"Error binding Port 8080: {e}")

```

Start the websocket with 

```
./MiniOmni.exe -w 
```

You should see that the exe is now running on the next available port. If 8081 is not bound you can see it running on 8081. 
