### PR TITLE
Feature/ Check for available port

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The CLI-Tool includes the following functionalities:
 -o, --output Writes the data from the selected devices to the specified file path. By default, the data is saved in .csv format.
 -j, --json Changes the output file format to JSON. 
 -w, --websocket Opens a Websocket, as well as a REST API. 
+-p, --port Set a port for the Websocket to start on. 
 -v, --verbose Prints out additional information about the software's process.
 --version Prints out the current SW version 
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -30,6 +30,9 @@ int main(int argc, char **argv) {
     bool WS = false;
     app.add_flag("-w,--websocket", WS, "Starts the websocket. To send data a UUID has to be given");
 
+    int port = 0;
+    app.add_option("-p, --port", port, "Sets the port for the websocket to start on.");
+
     bool printVersion = false;
     app.add_flag("--version", printVersion, "Prints the current version. Version is set via a git tag.");
 
@@ -50,13 +53,22 @@ int main(int argc, char **argv) {
         running = false;
     }
 
-    if(search) { // search for devices and print the UUID
+    if(port != 0 && WS == false ) {
+        std::cout << "You cant set a port if you dont start the websocket. Usage: Programm -w -p <port> ." << std::endl;
+        running = false;
+    }
+    if(port == 0 && WS == true ) {
+        std::cout << "You cant use a websocket without setting a port. Usage: Programm -w -p <port> ." << std::endl;
+        running = false;
+    }
+
+    if(search && running) { // search for devices and print the UUID
         searchDevices();
         printDevices();
     }
 
-    if(WS) {
-        websocket = std::thread(WSTest);
+    if(WS && running) {
+        websocket = std::thread(StartWS, std::ref(port));
     }
 
     DataDestination destination = DataDestination::WS;

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -586,7 +586,6 @@ void customSignalHandler(int signal) {
 }
 
 void ExitProgramm() {
-    std::cout << "Anzahl gesendeter Daten:" << Datenanzahl << std::endl;
     if(WEBSOCKET_ACTIVE) {
         crowApp.stop();
     }
@@ -868,7 +867,9 @@ double round_to(double value, int decimals) {
     return std::round(value * factor) / factor;
 }
 
-void WSTest() {
+/// WEBSOCKET HANDLING ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+void StartWS(int &port) {
     std::mutex mtx;
     std::unordered_set<crow::websocket::connection*> users;
     std::unordered_map<crow::websocket::connection*, std::atomic<bool>> thread_control_flags;
@@ -1022,5 +1023,4 @@ void processDeque(crow::websocket::connection& conn, std::shared_ptr<Measurement
         std::cout << "Processdeque stopped" << std::endl;
     }
 }
-
 


### PR DESCRIPTION
## What ? 
Feature to set the port for the websocket via the CLI Tool with -p, --port. 

## Why? 

As the user does not always have a certain port available this parameter should not be static and instead set by the user. 
As a better version to https://github.com/AI-Gruppe/OmnAIScope-DataServer/pull/29 . 

## Testing 

To test the behavior, compile the programm on Linux, RPI with Arm or Windows. In your CLI test the following commands. 

```
.\MiniOmni.exe -w -p <port>
```

Expected Behavior: Starts the websocket on the given port if the port is free . 

```
.\MiniOmni.exe -w 
```
Expected Behavior: Displays : 

```
You cant use a websocket without setting a port. Usage: Programm -w -p <port> .
Programm was closed correctly, all threads closed
```

```
.\MiniOmni.exe -p 
```
Expected Behavior: Displays : 

```
You cant set a port if you dont start the websocket. Usage: Programm -w -p <port> .
Programm was closed correctly, all threads closed. 
```

