### PR TITLE
Quick Fix: Use given port as port for ws

### DIFF
--- a/src/data.hpp
+++ b/src/data.hpp
@@ -947,7 +947,7 @@ void StartWS(int &port) {
     crowApp.signal_clear();
     std::signal(SIGINT, customSignalHandler);
 
-    crowApp.port(8080).multithreaded().run();
+    crowApp.port(port).multithreaded().run();
 }
 
 Measurement parseWSDataToMeasurement(const std::string& data) {


### PR DESCRIPTION
The Port was only set in the CLI Tool not used by the Websocket 