### PR TITLE
Changing Project name to OmnAIScopeBackend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(PROJECT_NAME "MiniOmni")
+set(PROJECT_NAME "OmnAIScopeBackend")
 
 include(FetchContent)
 FetchContent_Populate(


### PR DESCRIPTION
As the project transformed from an example project to the real used OmnAIScope Backend, MiniOmni isn't ann appropiate name for the backend anymore. 

Therefore the applications name was changed to "OmnAIScopeBackend"